### PR TITLE
Update EDA_TTCsubwaydelay_levinemich.ipynb

### DIFF
--- a/EDA_TTCsubwaydelay_levinemich.ipynb
+++ b/EDA_TTCsubwaydelay_levinemich.ipynb
@@ -3122,7 +3122,7 @@
     }
    ],
    "source": [
-    "final_df[final_df['line'].isna()]"
+    "final_df[final_df['line'].isna()].head(10)"
    ]
   },
   {


### PR DESCRIPTION
Limited the number of records with na for line that appear in the notebook.